### PR TITLE
DB 간헐적 connection 오류 수정

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ spring:
   profiles:
     include: info
   datasource:
-    url: jdbc:postgresql://aws-0-ap-northeast-2.pooler.supabase.com:6543/postgres
+    url: jdbc:postgresql://aws-0-ap-northeast-2.pooler.supabase.com:6543/postgres?prepareThreshold=0
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
   jpa:


### PR DESCRIPTION
## 개요
 - postgreSql에 connection 연결 시도할 때 간헐적으로 오류가 발생함
 - supabase의 transaction 모드를 사용하는 경우 트랜잭션이 동작할 때 prepareThreshold로 인해 붙잡고 있던 prepared statement를 동일한 이름으로 사용하는 걸로 추측
 - pooler는 사용하고 싶기 때문에 2안 채택

## 해결 방안
1, 연결 포트를 5432로 변경 (session 모드), supabase의 connection pool size를 늘린다.
### 2, 6543 포트를 그대로 사용하고 `prepareThreshold=0` 옵션을 추가한다. (채택)
 
## 문제 발생 상황
 - 앱 재시작 후 쿼리 실행하는 경우
 - 테스트 케이스 실행하는 경우

## 수정
 - datasource url에 `prepareThreshold=0` 추가

## 참고 자료
 - https://stackoverflow.com/questions/7611926/postgres-error-prepared-statement-s-1-already-exists 
 - https://github.com/pgjdbc/pgjdbc/issues/596
 - https://velog.io/@dongho18/%ED%8A%B8%EB%9F%AC%EB%B8%94%EC%8A%88%ED%8C%85-Supabase-Max-client-connections-reached

 ## 발생한 오류
  - Hibernate transaction: Unable to rollback against JDBC Connection; bad SQL grammar
  - Unable to release JDBC Connection [ERROR: prepared statement "S_2" already exists]
  - FATAL: Max client connections reached