### PR TITLE
Jwt 검증 응답 방식 변경

### DIFF
--- a/src/main/java/com/kinuk/api/config/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/kinuk/api/config/security/JwtAuthenticationEntryPoint.java
@@ -28,7 +28,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
         response.setStatus(ApiResponseCode.INVALID_TOKEN.getHttpStatus().value());
-        response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.fail(ApiResponseCode.INVALID_TOKEN.getMessage())));
+        response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.fail(request.getAttribute("jwt_result").toString())));
         response.getWriter().flush();
     }
 }

--- a/src/main/java/com/kinuk/api/config/security/SecurityConfig.java
+++ b/src/main/java/com/kinuk/api/config/security/SecurityConfig.java
@@ -1,14 +1,11 @@
 package com.kinuk.api.config.security;
 
-import com.kinuk.api.filter.JwtExceptionHandlerFilter;
 import com.kinuk.api.filter.JwtFilter;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
@@ -24,9 +21,6 @@ public class SecurityConfig {
     @Autowired
     private JwtAuthenticationEntryPoint entryPoint;
 
-    @Autowired
-    private JwtExceptionHandlerFilter jwtExceptionHandlerFilter;
-
     /**
      * Spring Security 설정
      */
@@ -39,40 +33,15 @@ public class SecurityConfig {
                 .sessionManagement(it -> it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 비활성화
                 .authorizeHttpRequests(authorize -> {
                             authorize
-                                    .requestMatchers("/v3/**", "/swagger-ui/**").permitAll() // Swagger Auth 제외 설정
+                                    .requestMatchers("/v3/**", "/swagger-ui/**", "/swagger-ui.html").permitAll() // Swagger Auth 제외 설정
                                     .requestMatchers("/api/user/signup", "/api/user/login").permitAll() // 회원가입, 로그인
                                     .anyRequest().authenticated(); // 이외의 요청은 Jwt 토큰 검증 필요
                         }
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class) // Jwt 사용자 인증 필터
-                .addFilterBefore(jwtExceptionHandlerFilter, JwtFilter.class) // Jwt 필터에서 throw 하는 Exception handler
                 .exceptionHandling(it -> it.authenticationEntryPoint(entryPoint)) // 사용자 인증에 실패한 경우 response 처리
         ;
 
         return http.build();
     }
-
-    /**
-     * permit_url 은 security 설정 무시하도록 설정
-     */
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring()
-                .requestMatchers(
-                        "/v3/**", "/swagger-ui/**",
-                        "/api/user/signup", "/api/user/login"
-                );
-    }
-
-    /**
-     * Jwt 필터가 자동으로 servletFilter 에도 등록이 되어 ignore 했음에도 불구하고 filter 로 걸러지는 경우가 발생
-     * 자동으로 jwtFilter 가 등록되지 않도록 설정
-     */
-    @Bean
-    public FilterRegistrationBean<JwtFilter> registration(JwtFilter filter) {
-        FilterRegistrationBean<JwtFilter> registration = new FilterRegistrationBean<>(filter);
-        registration.setEnabled(false);
-        return registration;
-    }
-
 }

--- a/src/main/java/com/kinuk/api/util/JwtUtil.java
+++ b/src/main/java/com/kinuk/api/util/JwtUtil.java
@@ -1,7 +1,6 @@
 package com.kinuk.api.util;
 
 import com.kinuk.api.exception.ApiResponseCode;
-import com.kinuk.api.exception.JwtTokenException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -59,28 +58,29 @@ public class JwtUtil {
      * 토큰 검증 함수
      *
      * @param token - 발급된 토큰
-     * @return - 검증 완료: true, 검증 실패: false
+     * @return - null || ApiResponseCode
      */
-    public boolean validateToken(String token) {
+    public ApiResponseCode validateToken(String token) {
         try {
             extractClaims(token);
-            return true;
         } catch (SecurityException | MalformedJwtException e) {
             // 유효하지 않은 토큰
-            throw new JwtTokenException(ApiResponseCode.INVALID_TOKEN);
+            return ApiResponseCode.INVALID_TOKEN;
         } catch (ExpiredJwtException e) {
             // 만료된 토큰
-            throw new JwtTokenException(ApiResponseCode.EXPIRED_TOKEN);
+            return ApiResponseCode.EXPIRED_TOKEN;
         } catch (UnsupportedJwtException e) {
             // 지원하지 않는 토큰
-            throw new JwtTokenException(ApiResponseCode.UNSUPPORTED_TOKEN);
+            return ApiResponseCode.UNSUPPORTED_TOKEN;
         } catch (IllegalArgumentException e) {
             // claims 가 정상이 아닌 경우
-            throw new JwtTokenException(ApiResponseCode.EMPTY_TOKEN);
+            return ApiResponseCode.EMPTY_TOKEN;
         } catch (Exception e) {
             log.info("Jwt Token Exception", e);
-            throw new JwtTokenException(ApiResponseCode.EXCEPTION_TOKEN);
+            return ApiResponseCode.EXCEPTION_TOKEN;
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
## 수정 이유
- ignore 설정, permitAll url을 2번 처리하는 문제
- fliter에서 throw exception 을 통해 api 응답

## 수정 내용
- security 설정에 jwt 필터의 필터 등록 제외 Bean 제거
- security ignore 설정 Bean 제거
- jwtUtil 에서는 Exception 던지는 방식에서 토큰 검증 유형에 따라 메세지 String return
- ExceptionHandler 에서 응답 처리하는 방식에서 EntryPoint 하나로 처리